### PR TITLE
fix: concurrent map write issue

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -412,7 +412,7 @@ func NewBlockChain(db ethdb.Database, cacheConfig *CacheConfig, genesis *Genesis
 	// Make sure the state associated with the block is available, or log out
 	// if there is no available state, waiting for state sync.
 	head := bc.CurrentBlock()
-	if !bc.NoTries() && !bc.HasState(head.Root) {
+	if !bc.HasState(head.Root) {
 		if head.Number.Uint64() == 0 {
 			// The genesis state is missing, which is only possible in the path-based
 			// scheme. This situation occurs when the initial state sync is not finished

--- a/miner/worker_builder.go
+++ b/miner/worker_builder.go
@@ -284,6 +284,7 @@ func (w *worker) simulateBundles(env *environment, bundles []*types.Bundle) ([]*
 	simResult := make(map[common.Hash]*types.SimulatedBundle)
 
 	var wg sync.WaitGroup
+	var mu sync.Mutex
 	for i, bundle := range bundles {
 		if simmed, ok := simCache.GetSimulatedBundle(bundle.Hash()); ok {
 			simResult[bundle.Hash()] = simmed
@@ -301,6 +302,8 @@ func (w *worker) simulateBundles(env *environment, bundles []*types.Bundle) ([]*
 				return
 			}
 
+			mu.Lock()
+			defer mu.Unlock()
 			simResult[bundle.Hash()] = simmed
 		}(i, bundle, env.state.Copy())
 	}

--- a/miner/worker_builder.go
+++ b/miner/worker_builder.go
@@ -287,7 +287,9 @@ func (w *worker) simulateBundles(env *environment, bundles []*types.Bundle) ([]*
 	var mu sync.Mutex
 	for i, bundle := range bundles {
 		if simmed, ok := simCache.GetSimulatedBundle(bundle.Hash()); ok {
+			mu.Lock()
 			simResult[bundle.Hash()] = simmed
+			mu.Unlock()
 			continue
 		}
 


### PR DESCRIPTION
### Description

This ps is to fix a concurrent map write issue in `simulateBundles` of `work_builder`

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add write lock for simulation results map
* remove check of `bc.NoTries()` to prevent snapsync
