### PR TITLE
fix: typo in `BundlePool.AllBundles`

### DIFF
--- a/core/txpool/bundlepool/bundlepool.go
+++ b/core/txpool/bundlepool/bundlepool.go
@@ -191,7 +191,7 @@ func (p *BundlePool) PendingBundles(blockNumber uint64, blockTimestamp uint64) [
 
 // AllBundles returns all the bundles currently in the pool
 func (p *BundlePool) AllBundles() []*types.Bundle {
-	p.mu.RUnlock()
+	p.mu.RLock()
 	defer p.mu.RUnlock()
 	bundles := make([]*types.Bundle, 0, len(p.bundles))
 	for _, bundle := range p.bundles {


### PR DESCRIPTION
### Description

This pr is to fix a typo.

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* Change from `p.mu.RUnlock()` to `p.mu.RLock()`
