### PR TITLE
feat: add `reconnectLoop` for mev validators

### DIFF
--- a/miner/bidder.go
+++ b/miner/bidder.go
@@ -149,12 +149,12 @@ func (b *Bidder) mainLoop() {
 func (b *Bidder) reconnectLoop() {
 	defer b.wg.Done()
 
-	timer := time.NewTimer(10 * time.Minute)
-	defer timer.Stop()
+	ticker := time.NewTicker(10 * time.Minute)
+	defer ticker.Stop()
 
 	for {
 		select {
-		case <-timer.C:
+		case <-ticker.C:
 			for _, v := range b.config.Validators {
 				if b.isRegistered(v.Address) {
 					continue
@@ -162,8 +162,6 @@ func (b *Bidder) reconnectLoop() {
 
 				b.register(v)
 			}
-
-			timer.Reset(10 * time.Minute)
 		case <-b.exitCh:
 			return
 		}

--- a/miner/bidder.go
+++ b/miner/bidder.go
@@ -2,6 +2,7 @@ package miner
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"time"
 
@@ -16,7 +17,6 @@ import (
 	"github.com/ethereum/go-ethereum/miner/validatorclient"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/rpc"
-	"errors"
 )
 
 const maxBid int64 = 3

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1169,7 +1169,7 @@ func (w *worker) commitWork(interruptCh chan int32, timestamp int64) {
 			}
 
 			// do not build work if not register to the coinbase
-			if !w.bidder.registered(coinbase) {
+			if !w.bidder.isRegistered(coinbase) {
 				log.Warn("Refusing to mine with unregistered validator")
 				return
 			}

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1182,9 +1182,11 @@ func (w *worker) commitWork(interruptCh chan int32, timestamp int64) {
 				return
 			}
 
+			w.bidder.validatorsMu.Lock()
 			if w.bidder.validators[coinbase] != nil {
 				w.config.GasCeil = w.bidder.validators[coinbase].GasCeil
 			}
+			w.bidder.validatorsMu.Unlock()
 		} else {
 			coinbase = w.etherbase()
 			if coinbase == (common.Address{}) {


### PR DESCRIPTION
### Description

This pr is to add `reconnectLoop` for mev validators

### Rationale

To make the bidder reconnect to offline validators automatically.

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add `reconnectLoop` for mev validators
