### PR TITLE
fix: bug in profit calculation

### DIFF
--- a/miner/worker_builder.go
+++ b/miner/worker_builder.go
@@ -447,6 +447,12 @@ func (w *worker) simulateBundle(
 		}
 		txGasFees := new(big.Int).Mul(txGasUsed, effectiveTip)
 		bundleGasFees.Add(bundleGasFees, txGasFees)
+
+		if tx.Type() == types.BlobTxType {
+			blobFee := new(big.Int).SetUint64(receipt.BlobGasUsed)
+			blobFee.Mul(blobFee, receipt.BlobGasPrice)
+			bundleGasFees.Add(bundleGasFees, blobFee)
+		}
 		sysBalanceAfter := state.GetBalance(consensus.SystemAddress)
 		sysDelta := new(uint256.Int).Sub(sysBalanceAfter, sysBalanceBefore)
 		sysDelta.Sub(sysDelta, uint256.MustFromBig(txGasFees))

--- a/miner/worker_builder.go
+++ b/miner/worker_builder.go
@@ -441,7 +441,11 @@ func (w *worker) simulateBundle(
 		bundleGasUsed += receipt.GasUsed
 
 		txGasUsed := new(big.Int).SetUint64(receipt.GasUsed)
-		txGasFees := new(big.Int).Mul(txGasUsed, tx.GasPrice())
+		effectiveTip, err := tx.EffectiveGasTip(env.header.BaseFee)
+		if err != nil {
+			return nil, err
+		}
+		txGasFees := new(big.Int).Mul(txGasUsed, effectiveTip)
 		bundleGasFees.Add(bundleGasFees, txGasFees)
 		sysBalanceAfter := state.GetBalance(consensus.SystemAddress)
 		sysDelta := new(uint256.Int).Sub(sysBalanceAfter, sysBalanceBefore)

--- a/miner/worker_builder.go
+++ b/miner/worker_builder.go
@@ -446,13 +446,13 @@ func (w *worker) simulateBundle(
 			return nil, err
 		}
 		txGasFees := new(big.Int).Mul(txGasUsed, effectiveTip)
-		bundleGasFees.Add(bundleGasFees, txGasFees)
 
 		if tx.Type() == types.BlobTxType {
 			blobFee := new(big.Int).SetUint64(receipt.BlobGasUsed)
 			blobFee.Mul(blobFee, receipt.BlobGasPrice)
-			bundleGasFees.Add(bundleGasFees, blobFee)
+			txGasFees.Add(txGasFees, blobFee)
 		}
+		bundleGasFees.Add(bundleGasFees, txGasFees)
 		sysBalanceAfter := state.GetBalance(consensus.SystemAddress)
 		sysDelta := new(uint256.Int).Sub(sysBalanceAfter, sysBalanceBefore)
 		sysDelta.Sub(sysDelta, uint256.MustFromBig(txGasFees))


### PR DESCRIPTION
1. Currently, the worker uses GasPrice to calculate profit when committing a transaction. This method has issues when calculating EIP1559-type transactions. Refer to https://github.com/bnb-chain/bsc-builder/blob/b0668a82c7dbe20dae3b7874ffce4aba9e57ccd9/core/state_transition.go#L464 and use EffectiveGasTip to calculate the transaction fee.

2. When calculating blob-type transactions, the blob fee needs to be included.