### PR TITLE
fix: only take non-mempool tx to calculate bundle price

### DIFF
--- a/core/types/bundle_gasless.go
+++ b/core/types/bundle_gasless.go
@@ -1,0 +1,21 @@
+package types
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+)
+
+type SimulateGaslessBundleArgs struct {
+	Txs []hexutil.Bytes `json:"txs"`
+}
+
+type GaslessTxSimResult struct {
+	Hash    common.Hash
+	GasUsed uint64
+	Valid   bool
+}
+
+type SimulateGaslessBundleResp struct {
+	Results          []GaslessTxSimResult
+	BasedBlockNumber int64
+}

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -304,6 +304,10 @@ func (b *EthAPIBackend) SendBundle(ctx context.Context, bundle *types.Bundle) er
 	return b.eth.txPool.AddBundle(bundle)
 }
 
+func (b *EthAPIBackend) SimulateGaslessBundle(bundle *types.Bundle) (*types.SimulateGaslessBundleResp, error) {
+	return b.Miner().SimulateGaslessBundle(bundle)
+}
+
 func (b *EthAPIBackend) BundlePrice() *big.Int {
 	bundles := b.eth.txPool.AllBundles()
 	gasFloor := big.NewInt(b.eth.config.Miner.MevGasPriceFloor)

--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -779,6 +779,16 @@ func (ec *Client) BestBidGasFee(ctx context.Context, parentHash common.Hash) (*b
 	return fee, nil
 }
 
+// SimulateGaslessBundle simulates a gasless bundle
+func (ec *Client) SimulateGaslessBundle(ctx context.Context, args types.SimulateGaslessBundleArgs) (*types.SimulateGaslessBundleResp, error) {
+	var bundle types.SimulateGaslessBundleResp
+	err := ec.c.CallContext(ctx, &bundle, "eth_simulateGaslessBundle", args)
+	if err != nil {
+		return nil, err
+	}
+	return &bundle, nil
+}
+
 // SendBundle sends a bundle
 func (ec *Client) SendBundle(ctx context.Context, args types.SendBundleArgs) (common.Hash, error) {
 	var hash common.Hash

--- a/internal/ethapi/api_bundle.go
+++ b/internal/ethapi/api_bundle.go
@@ -25,6 +25,29 @@ func (s *PrivateTxBundleAPI) BundlePrice(ctx context.Context) *big.Int {
 	return s.b.BundlePrice()
 }
 
+// SimulateGaslessBundle simulates the execution of a list of transactions with order
+func (s *PrivateTxBundleAPI) SimulateGaslessBundle(_ context.Context, args types.SimulateGaslessBundleArgs) (*types.SimulateGaslessBundleResp, error) {
+	if len(args.Txs) == 0 {
+		return nil, newBundleError(errors.New("bundle missing txs"))
+	}
+
+	var txs types.Transactions
+
+	for _, encodedTx := range args.Txs {
+		tx := new(types.Transaction)
+		if err := tx.UnmarshalBinary(encodedTx); err != nil {
+			return nil, err
+		}
+		txs = append(txs, tx)
+	}
+
+	bundle := &types.Bundle{
+		Txs: txs,
+	}
+
+	return s.b.SimulateGaslessBundle(bundle)
+}
+
 // SendBundle will add the signed transaction to the transaction pool.
 // The sender is responsible for signing the transaction and using the correct nonce and ensuring validity
 func (s *PrivateTxBundleAPI) SendBundle(ctx context.Context, args types.SendBundleArgs) (common.Hash, error) {

--- a/internal/ethapi/api_test.go
+++ b/internal/ethapi/api_test.go
@@ -615,6 +615,10 @@ func (b testBackend) SendTx(ctx context.Context, signedTx *types.Transaction) er
 func (b testBackend) SendBundle(ctx context.Context, bundle *types.Bundle) error {
 	panic("implement me")
 }
+func (b *testBackend) SimulateGaslessBundle(bundle *types.Bundle) (*types.SimulateGaslessBundleResp, error) {
+	//TODO implement me
+	panic("implement me")
+}
 func (b testBackend) BundlePrice() *big.Int {
 	panic("implement me")
 }

--- a/internal/ethapi/backend.go
+++ b/internal/ethapi/backend.go
@@ -79,6 +79,7 @@ type Backend interface {
 	// Transaction pool API
 	SendTx(ctx context.Context, signedTx *types.Transaction) error
 	SendBundle(ctx context.Context, bundle *types.Bundle) error
+	SimulateGaslessBundle(bundle *types.Bundle) (*types.SimulateGaslessBundleResp, error)
 	BundlePrice() *big.Int
 	GetTransaction(ctx context.Context, txHash common.Hash) (bool, *types.Transaction, common.Hash, uint64, uint64, error)
 	GetPoolTransactions() (types.Transactions, error)

--- a/internal/ethapi/transaction_args_test.go
+++ b/internal/ethapi/transaction_args_test.go
@@ -389,7 +389,11 @@ func (b *backendMock) SubscribeNewVoteEvent(ch chan<- core.NewVoteEvent) event.S
 }
 func (b *backendMock) SendTx(ctx context.Context, signedTx *types.Transaction) error { return nil }
 func (b *backendMock) SendBundle(ctx context.Context, bundle *types.Bundle) error    { return nil }
-func (b *backendMock) BundlePrice() *big.Int                                         { return nil }
+func (b *backendMock) SimulateGaslessBundle(bundle *types.Bundle) (*types.SimulateGaslessBundleResp, error) {
+	//TODO implement me
+	panic("implement me")
+}
+func (b *backendMock) BundlePrice() *big.Int { return nil }
 func (b *backendMock) GetTransaction(ctx context.Context, txHash common.Hash) (bool, *types.Transaction, common.Hash, uint64, uint64, error) {
 	return false, nil, [32]byte{}, 0, 0, nil
 }

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -18,7 +18,6 @@
 package miner
 
 import (
-	"errors"
 	"fmt"
 	"math/big"
 	"sync"
@@ -368,14 +367,12 @@ func (miner *Miner) SimulateBundle(bundle *types.Bundle) (*big.Int, error) {
 		systemcontracts.UpgradeBuildInSystemContract(miner.worker.chainConfig, header.Number, parent.Time, header.Time, env.state)
 	}
 
-	s, err := miner.worker.simulateBundles(env, []*types.Bundle{bundle})
+	gasPool := prepareGasPool(env.header.GasLimit)
+	s, err := miner.worker.simulateBundle(env, bundle, state, gasPool, 0, true, true)
+
 	if err != nil {
 		return nil, err
 	}
 
-	if len(s) == 0 {
-		return nil, errors.New("no valid sim result")
-	}
-
-	return s[0].BundleGasPrice, nil
+	return s.BundleGasPrice, nil
 }

--- a/miner/worker_builder.go
+++ b/miner/worker_builder.go
@@ -530,7 +530,6 @@ func (w *worker) simulateGaslessBundle(env *environment, bundle *types.Bundle) (
 		Results:          result,
 		BasedBlockNumber: env.header.Number.Int64(),
 	}, nil
-
 }
 
 func containsHash(arr []common.Hash, match common.Hash) bool {

--- a/miner/worker_builder.go
+++ b/miner/worker_builder.go
@@ -448,6 +448,7 @@ func (w *worker) simulateBundle(
 			}
 
 			if env.header.BaseFee != nil {
+				log.Info("simulate bundle: header base fee", "value", env.header.BaseFee.String())
 				effectiveTip.Add(effectiveTip, env.header.BaseFee)
 			}
 

--- a/miner/worker_builder.go
+++ b/miner/worker_builder.go
@@ -438,39 +438,51 @@ func (w *worker) simulateBundle(
 			return nil, err
 		}
 
-		bundleGasUsed += receipt.GasUsed
+		if !w.eth.TxPool().Has(tx.Hash()) {
+			bundleGasUsed += receipt.GasUsed
 
-		txGasUsed := new(big.Int).SetUint64(receipt.GasUsed)
-		effectiveTip, err := tx.EffectiveGasTip(env.header.BaseFee)
-		if err != nil {
-			return nil, err
-		}
-		txGasFees := new(big.Int).Mul(txGasUsed, effectiveTip)
+			txGasUsed := new(big.Int).SetUint64(receipt.GasUsed)
+			effectiveTip, er := tx.EffectiveGasTip(env.header.BaseFee)
+			if er != nil {
+				return nil, er
+			}
 
-		if tx.Type() == types.BlobTxType {
-			blobFee := new(big.Int).SetUint64(receipt.BlobGasUsed)
-			blobFee.Mul(blobFee, receipt.BlobGasPrice)
-			txGasFees.Add(txGasFees, blobFee)
+			if env.header.BaseFee != nil {
+				effectiveTip.Add(effectiveTip, env.header.BaseFee)
+			}
+
+			txGasFees := new(big.Int).Mul(txGasUsed, effectiveTip)
+
+			if tx.Type() == types.BlobTxType {
+				blobFee := new(big.Int).SetUint64(receipt.BlobGasUsed)
+				blobFee.Mul(blobFee, receipt.BlobGasPrice)
+				txGasFees.Add(txGasFees, blobFee)
+			}
+			bundleGasFees.Add(bundleGasFees, txGasFees)
+			sysBalanceAfter := state.GetBalance(consensus.SystemAddress)
+			sysDelta := new(uint256.Int).Sub(sysBalanceAfter, sysBalanceBefore)
+			sysDelta.Sub(sysDelta, uint256.MustFromBig(txGasFees))
+			ethSentToSystem.Add(ethSentToSystem, sysDelta.ToBig())
 		}
-		bundleGasFees.Add(bundleGasFees, txGasFees)
-		sysBalanceAfter := state.GetBalance(consensus.SystemAddress)
-		sysDelta := new(uint256.Int).Sub(sysBalanceAfter, sysBalanceBefore)
-		sysDelta.Sub(sysDelta, uint256.MustFromBig(txGasFees))
-		ethSentToSystem.Add(ethSentToSystem, sysDelta.ToBig())
 	}
 
-	bundleGasPrice := new(big.Int).Div(bundleGasFees, new(big.Int).SetUint64(bundleGasUsed))
+	// if all txs in the bundle are from mempool, we accept the bundle without checking gas price
+	bundleGasPrice := big.NewInt(0)
 
-	if bundleGasPrice.Cmp(big.NewInt(w.config.MevGasPriceFloor)) < 0 {
-		err := errBundlePriceTooLow
-		log.Warn("fail to simulate bundle", "hash", bundle.Hash().String(), "err", err)
+	if bundleGasUsed != 0 {
+		bundleGasPrice = new(big.Int).Div(bundleGasFees, new(big.Int).SetUint64(bundleGasUsed))
 
-		if prune {
-			log.Warn("prune bundle", "hash", bundle.Hash().String())
-			w.eth.TxPool().PruneBundle(bundle.Hash())
+		if bundleGasPrice.Cmp(big.NewInt(w.config.MevGasPriceFloor)) < 0 {
+			err := errBundlePriceTooLow
+			log.Warn("fail to simulate bundle", "hash", bundle.Hash().String(), "err", err)
+
+			if prune {
+				log.Warn("prune bundle", "hash", bundle.Hash().String())
+				w.eth.TxPool().PruneBundle(bundle.Hash())
+			}
+
+			return nil, err
 		}
-
-		return nil, err
 	}
 
 	return &types.SimulatedBundle{


### PR DESCRIPTION
### Description

fix: only take non-mempool tx to calculate bundle price

### Rationale

In current implementation, when a builder receive a bundle, it will simulate all txs within the bundle. Bundle price = sum( gas price * gas used ) /sum(gas used ) , ensure bundle price > = 1 gwei. It seems not a good solution. Consider the following example:
There is a public mempool tx with 100 gwei, gas usage 21,000 and its a simple transfer tx. A malicious actor can submit a 0 gas price tx to bundle it up with the public mempool tx, this tx has 0 gwei gas price, it can involve very complex smart contract calls and it has a gas usage of 1,000,000.
In that case, it will be (10021000+01000000)/(21000+1000000)=2.05 gwei. This means this bundle can be included by builders and land on chain.
However, the malicious actor is essentially a "free rider" in this scenario, and this actor is able to "exploit" the bundle scoring algorithm and make high-gas-usage tx land on chain for free.

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
