### PR TITLE
fix: temporarily reduce gaslimit when fill txs for builder block

### DIFF
--- a/core/block_validator.go
+++ b/core/block_validator.go
@@ -256,8 +256,3 @@ func CalcGasLimit(parentGasLimit, desiredLimit uint64) uint64 {
 	}
 	return limit
 }
-
-// CalcGasLimitForBuilder computes the gas limit of the next block.
-func CalcGasLimitForBuilder(parentGasLimit, desiredLimit uint64) uint64 {
-	return CalcGasLimit(parentGasLimit, desiredLimit) / 2
-}

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -373,7 +373,7 @@ func (miner *Miner) prepareSimulationEnv(parent *types.Header, state *state.Stat
 	header := &types.Header{
 		ParentHash: parent.Hash(),
 		Number:     new(big.Int).Add(parent.Number, common.Big1),
-		GasLimit:   core.CalcGasLimitForBuilder(parent.GasLimit, miner.worker.config.GasCeil),
+		GasLimit:   core.CalcGasLimit(parent.GasLimit, miner.worker.config.GasCeil),
 		Extra:      miner.worker.extra,
 		Time:       uint64(timestamp),
 		Coinbase:   coinbase,

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1033,10 +1033,11 @@ func (w *worker) prepareWork(genParams *generateParams) (*environment, error) {
 	header := &types.Header{
 		ParentHash: parent.Hash(),
 		Number:     new(big.Int).Add(parent.Number, common.Big1),
-		GasLimit:   core.CalcGasLimitForBuilder(parent.GasLimit, w.config.GasCeil),
+		GasLimit:   core.CalcGasLimit(parent.GasLimit, w.config.GasCeil),
 		Time:       timestamp,
 		Coinbase:   genParams.coinbase,
 	}
+
 	// Set the extra field.
 	if len(w.extra) != 0 {
 		header.Extra = w.extra
@@ -1050,7 +1051,7 @@ func (w *worker) prepareWork(genParams *generateParams) (*environment, error) {
 		header.BaseFee = eip1559.CalcBaseFee(w.chainConfig, parent)
 		if w.chainConfig.Parlia == nil && !w.chainConfig.IsLondon(parent.Number) {
 			parentGasLimit := parent.GasLimit * w.chainConfig.ElasticityMultiplier()
-			header.GasLimit = core.CalcGasLimitForBuilder(parentGasLimit, w.config.GasCeil)
+			header.GasLimit = core.CalcGasLimit(parentGasLimit, w.config.GasCeil)
 		}
 	}
 	// Run the consensus preparation with the default or customized consensus engine.

--- a/miner/worker_builder.go
+++ b/miner/worker_builder.go
@@ -32,6 +32,14 @@ var (
 func (w *worker) fillTransactionsAndBundles(interruptCh chan int32, env *environment, stopTimer *time.Timer) error {
 	env.state.StopPrefetcher() // no need to prefetch txs for a builder
 
+	// reduce gas limit for builder block
+	fullGasLimit := env.header.GasLimit
+	env.header.GasLimit /= 2
+
+	defer func() {
+		env.header.GasLimit = fullGasLimit
+	}()
+
 	var (
 		localPlainTxs  map[common.Address][]*txpool.LazyTransaction
 		remotePlainTxs map[common.Address][]*txpool.LazyTransaction


### PR DESCRIPTION
### Description

Builder block need to reduce gas limit for MEV performance, but if we directly change the gas limit in header, it would influence many unit test such as `TestWaitDeployed`, the test chain could not be work normally. So only set gas limit before fill transactions for builder block and reset it as the original value after filling done.

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
