### PR TITLE
fix: revert for droppable tx receipt failed

### DIFF
--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -122,7 +122,7 @@ func (b *BlockGen) addTx(bc *BlockChain, vmConfig vm.Config, tx *types.Transacti
 		evm          = vm.NewEVM(blockContext, b.statedb, b.cm.config, vmConfig)
 	)
 	b.statedb.SetTxContext(tx.Hash(), len(b.txs))
-	receipt, err := ApplyTransaction(evm, b.gasPool, b.statedb, b.header, tx, &b.header.GasUsed, NewReceiptBloomGenerator())
+	receipt, err := ApplyTransaction(evm, b.gasPool, b.statedb, b.header, tx, &b.header.GasUsed, false, NewReceiptBloomGenerator())
 	if err != nil {
 		panic(err)
 	}

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -1166,7 +1166,7 @@ func (api *API) traceTx(ctx context.Context, tx *types.Transaction, message *cor
 
 	// Call Prepare to clear out the statedb access list
 	statedb.SetTxContext(txctx.TxHash, txctx.TxIndex)
-	_, err = core.ApplyTransactionWithEVM(message, new(core.GasPool).AddGas(message.GasLimit), statedb, vmctx.BlockNumber, txctx.BlockHash, tx, &usedGas, evm)
+	_, err = core.ApplyTransactionWithEVM(message, new(core.GasPool).AddGas(message.GasLimit), statedb, vmctx.BlockNumber, txctx.BlockHash, tx, &usedGas, evm, false)
 	if err != nil {
 		return nil, fmt.Errorf("tracing failed: %w", err)
 	}

--- a/miner/bid_simulator.go
+++ b/miner/bid_simulator.go
@@ -839,7 +839,7 @@ func (r *BidRuntime) commitTransaction(chain *core.BlockChain, chainConfig *para
 		}
 		// Checking against blob gas limit: It's kind of ugly to perform this check here, but there
 		// isn't really a better place right now. The blob gas limit is checked at block validation time
-		// and not during execution. This means core.ApplyTranbisaction will not return an error if the
+		// and not during execution. This means core.ApplyTransaction will not return an error if the
 		// tx has too many blobs. So we have to explicitly check it here.
 		if (env.blobs + len(sc.Blobs)) > params.MaxBlobsPerBlockForBSC {
 			return errors.New("max data blobs reached")
@@ -847,7 +847,7 @@ func (r *BidRuntime) commitTransaction(chain *core.BlockChain, chainConfig *para
 	}
 
 	receipt, err := core.ApplyTransaction(env.evm, env.gasPool, env.state, env.header, tx,
-		&env.header.GasUsed, core.NewReceiptBloomGenerator())
+		&env.header.GasUsed, false, core.NewReceiptBloomGenerator())
 	if err != nil {
 		return err
 	} else if unRevertible && receipt.Status == types.ReceiptStatusFailed {

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -817,7 +817,7 @@ func (w *worker) applyTransaction(env *environment, tx *types.Transaction, recei
 		gp   = env.gasPool.Gas()
 	)
 
-	receipt, err := core.ApplyTransaction(env.evm, env.gasPool, env.state, env.header, tx, &env.header.GasUsed, receiptProcessors...)
+	receipt, err := core.ApplyTransaction(env.evm, env.gasPool, env.state, env.header, tx, &env.header.GasUsed, false, receiptProcessors...)
 	if err != nil {
 		env.state.RevertToSnapshot(snap)
 		env.gasPool.SetGas(gp)


### PR DESCRIPTION
### Description

This fix is for the following cases:
First, it needs to be clear that when evm execution is successful but receipt is failed, the state will finalise, and the external call layer cannot reset any operations on the state.

1. A droppable&unrevertible transaction is executed successfully at the index position N of the bundle, but receipt is false, and the gasfee is deducted from the sender balance.

2. If the droppable transaction is deleted, it is inconsistent with the evm state behavior. If the index of bundle is N+1 and there are transactions with the same sender, faults such as insufficient balance may occur, which is inconsistent with the expectation.

3. Solution: Extend the evm transaction execution method, when droppable transaction execution is successful but receipt is failed, it directly returns err, and the outer layer decides whether revert.

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
