### PR TITLE
fix: unit case of TestTransactionRollbackBehavior

### DIFF
--- a/ethclient/simulated/backend_test.go
+++ b/ethclient/simulated/backend_test.go
@@ -19,10 +19,14 @@ package simulated
 import (
 	"context"
 	"crypto/ecdsa"
+	"crypto/sha256"
 	"math/big"
 	"math/rand"
 	"testing"
 	"time"
+
+	"github.com/ethereum/go-ethereum/crypto/kzg4844"
+	"github.com/holiman/uint256"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
@@ -34,10 +38,10 @@ import (
 var _ bind.ContractBackend = (Client)(nil)
 
 var (
-	testKey, _ = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
-	testAddr   = crypto.PubkeyToAddress(testKey.PublicKey)
-	//testKey2, _ = crypto.HexToECDSA("7ee346e3f7efc685250053bfbafbfc880d58dc6145247053d4fb3cb0f66dfcb2")
-	//testAddr2   = crypto.PubkeyToAddress(testKey2.PublicKey)
+	testKey, _  = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
+	testAddr    = crypto.PubkeyToAddress(testKey.PublicKey)
+	testKey2, _ = crypto.HexToECDSA("7ee346e3f7efc685250053bfbafbfc880d58dc6145247053d4fb3cb0f66dfcb2")
+	testAddr2   = crypto.PubkeyToAddress(testKey2.PublicKey)
 )
 
 func simTestBackend(testAddr common.Address) *Backend {
@@ -48,45 +52,45 @@ func simTestBackend(testAddr common.Address) *Backend {
 	)
 }
 
-//func newBlobTx(sim *Backend, key *ecdsa.PrivateKey) (*types.Transaction, error) {
-//	client := sim.Client()
-//
-//	testBlob := &kzg4844.Blob{0x00}
-//	testBlobCommit, _ := kzg4844.BlobToCommitment(testBlob)
-//	testBlobProof, _ := kzg4844.ComputeBlobProof(testBlob, testBlobCommit)
-//	testBlobVHash := kzg4844.CalcBlobHashV1(sha256.New(), &testBlobCommit)
-//
-//	head, _ := client.HeaderByNumber(context.Background(), nil) // Should be child's, good enough
-//	gasPrice := new(big.Int).Add(head.BaseFee, big.NewInt(params.GWei))
-//	gasPriceU256, _ := uint256.FromBig(gasPrice)
-//	gasTipCapU256, _ := uint256.FromBig(big.NewInt(params.GWei))
-//
-//	addr := crypto.PubkeyToAddress(key.PublicKey)
-//	chainid, _ := client.ChainID(context.Background())
-//	nonce, err := client.PendingNonceAt(context.Background(), addr)
-//	if err != nil {
-//		return nil, err
-//	}
-//
-//	chainidU256, _ := uint256.FromBig(chainid)
-//	tx := types.NewTx(&types.BlobTx{
-//		ChainID:    chainidU256,
-//		GasTipCap:  gasTipCapU256,
-//		GasFeeCap:  gasPriceU256,
-//		BlobFeeCap: uint256.NewInt(1),
-//		Gas:        21000,
-//		Nonce:      nonce,
-//		To:         addr,
-//		AccessList: nil,
-//		BlobHashes: []common.Hash{testBlobVHash},
-//		Sidecar: &types.BlobTxSidecar{
-//			Blobs:       []kzg4844.Blob{*testBlob},
-//			Commitments: []kzg4844.Commitment{testBlobCommit},
-//			Proofs:      []kzg4844.Proof{testBlobProof},
-//		},
-//	})
-//	return types.SignTx(tx, types.LatestSignerForChainID(chainid), key)
-//}
+func newBlobTx(sim *Backend, key *ecdsa.PrivateKey) (*types.Transaction, error) {
+	client := sim.Client()
+
+	testBlob := &kzg4844.Blob{0x00}
+	testBlobCommit, _ := kzg4844.BlobToCommitment(testBlob)
+	testBlobProof, _ := kzg4844.ComputeBlobProof(testBlob, testBlobCommit)
+	testBlobVHash := kzg4844.CalcBlobHashV1(sha256.New(), &testBlobCommit)
+
+	head, _ := client.HeaderByNumber(context.Background(), nil) // Should be child's, good enough
+	gasPrice := new(big.Int).Add(head.BaseFee, big.NewInt(params.GWei))
+	gasPriceU256, _ := uint256.FromBig(gasPrice)
+	gasTipCapU256, _ := uint256.FromBig(big.NewInt(params.GWei))
+
+	addr := crypto.PubkeyToAddress(key.PublicKey)
+	chainid, _ := client.ChainID(context.Background())
+	nonce, err := client.PendingNonceAt(context.Background(), addr)
+	if err != nil {
+		return nil, err
+	}
+
+	chainidU256, _ := uint256.FromBig(chainid)
+	tx := types.NewTx(&types.BlobTx{
+		ChainID:    chainidU256,
+		GasTipCap:  gasTipCapU256,
+		GasFeeCap:  gasPriceU256,
+		BlobFeeCap: uint256.NewInt(1),
+		Gas:        21000,
+		Nonce:      nonce,
+		To:         addr,
+		AccessList: nil,
+		BlobHashes: []common.Hash{testBlobVHash},
+		Sidecar: &types.BlobTxSidecar{
+			Blobs:       []kzg4844.Blob{*testBlob},
+			Commitments: []kzg4844.Commitment{testBlobCommit},
+			Proofs:      []kzg4844.Proof{testBlobProof},
+		},
+	})
+	return types.SignTx(tx, types.LatestSignerForChainID(chainid), key)
+}
 
 func newTx(sim *Backend, key *ecdsa.PrivateKey) (*types.Transaction, error) {
 	client := sim.Client()

--- a/ethclient/simulated/rollback_test.go
+++ b/ethclient/simulated/rollback_test.go
@@ -16,94 +16,103 @@
 
 package simulated
 
+import (
+	"context"
+	"crypto/ecdsa"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
 // TestTransactionRollbackBehavior tests that calling Rollback on the simulated backend doesn't prevent subsequent
 // addition of new transactions
-// TODO @eri.z if necessary to pass this case for builder
-//func TestTransactionRollbackBehavior(t *testing.T) {
-//	sim := NewBackend(
-//		types.GenesisAlloc{
-//			testAddr:  {Balance: big.NewInt(10000000000000000)},
-//			testAddr2: {Balance: big.NewInt(10000000000000000)},
-//		},
-//	)
-//	defer sim.Close()
-//	client := sim.Client()
-//
-//	btx0 := testSendSignedTx(t, testKey, sim, true)
-//	tx0 := testSendSignedTx(t, testKey2, sim, false)
-//	tx1 := testSendSignedTx(t, testKey2, sim, false)
-//
-//	sim.Rollback()
-//
-//	if pendingStateHasTx(client, btx0) || pendingStateHasTx(client, tx0) || pendingStateHasTx(client, tx1) {
-//		t.Fatalf("all transactions were not rolled back")
-//	}
-//
-//	btx2 := testSendSignedTx(t, testKey, sim, true)
-//	tx2 := testSendSignedTx(t, testKey2, sim, false)
-//	tx3 := testSendSignedTx(t, testKey2, sim, false)
-//
-//	sim.Commit()
-//
-//	if !pendingStateHasTx(client, btx2) || !pendingStateHasTx(client, tx2) || !pendingStateHasTx(client, tx3) {
-//		t.Fatalf("all post-rollback transactions were not included")
-//	}
-//}
+func TestTransactionRollbackBehavior(t *testing.T) {
+	sim := NewBackend(
+		types.GenesisAlloc{
+			testAddr:  {Balance: big.NewInt(10000000000000000)},
+			testAddr2: {Balance: big.NewInt(10000000000000000)},
+		},
+	)
+	defer sim.Close()
+	client := sim.Client()
+
+	btx0 := testSendSignedTx(t, testKey, sim, true)
+	tx0 := testSendSignedTx(t, testKey2, sim, false)
+	tx1 := testSendSignedTx(t, testKey2, sim, false)
+
+	sim.Rollback()
+
+	if pendingStateHasTx(client, btx0) || pendingStateHasTx(client, tx0) || pendingStateHasTx(client, tx1) {
+		t.Fatalf("all transactions were not rolled back")
+	}
+
+	btx2 := testSendSignedTx(t, testKey, sim, true)
+	tx2 := testSendSignedTx(t, testKey2, sim, false)
+	tx3 := testSendSignedTx(t, testKey2, sim, false)
+
+	sim.Commit()
+
+	if !pendingStateHasTx(client, btx2) || !pendingStateHasTx(client, tx2) || !pendingStateHasTx(client, tx3) {
+		t.Fatalf("all post-rollback transactions were not included")
+	}
+}
 
 // testSendSignedTx sends a signed transaction to the simulated backend.
 // It does not commit the block.
-//func testSendSignedTx(t *testing.T, key *ecdsa.PrivateKey, sim *Backend, isBlobTx bool) *types.Transaction {
-//	t.Helper()
-//	client := sim.Client()
-//	ctx := context.Background()
-//
-//	var (
-//		err      error
-//		signedTx *types.Transaction
-//	)
-//	if isBlobTx {
-//		signedTx, err = newBlobTx(sim, key)
-//	} else {
-//		signedTx, err = newTx(sim, key)
-//	}
-//	if err != nil {
-//		t.Fatalf("failed to create transaction: %v", err)
-//	}
-//
-//	if err = client.SendTransaction(ctx, signedTx); err != nil {
-//		t.Fatalf("failed to send transaction: %v", err)
-//	}
-//
-//	return signedTx
-//}
+func testSendSignedTx(t *testing.T, key *ecdsa.PrivateKey, sim *Backend, isBlobTx bool) *types.Transaction {
+	t.Helper()
+	client := sim.Client()
+	ctx := context.Background()
+
+	var (
+		err      error
+		signedTx *types.Transaction
+	)
+	if isBlobTx {
+		signedTx, err = newBlobTx(sim, key)
+	} else {
+		signedTx, err = newTx(sim, key)
+	}
+	if err != nil {
+		t.Fatalf("failed to create transaction: %v", err)
+	}
+
+	if err = client.SendTransaction(ctx, signedTx); err != nil {
+		t.Fatalf("failed to send transaction: %v", err)
+	}
+
+	return signedTx
+}
 
 // pendingStateHasTx returns true if a given transaction was successfully included as of the latest pending state.
-//func pendingStateHasTx(client Client, tx *types.Transaction) bool {
-//	ctx := context.Background()
-//
-//	var (
-//		receipt *types.Receipt
-//		err     error
-//	)
-//
-//	// Poll for receipt with timeout
-//	deadline := time.Now().Add(2 * time.Second)
-//	for time.Now().Before(deadline) {
-//		receipt, err = client.TransactionReceipt(ctx, tx.Hash())
-//		if err == nil && receipt != nil {
-//			break
-//		}
-//		time.Sleep(100 * time.Millisecond)
-//	}
-//
-//	if err != nil {
-//		return false
-//	}
-//	if receipt == nil {
-//		return false
-//	}
-//	if receipt.Status != types.ReceiptStatusSuccessful {
-//		return false
-//	}
-//	return true
-//}
+func pendingStateHasTx(client Client, tx *types.Transaction) bool {
+	ctx := context.Background()
+
+	var (
+		receipt *types.Receipt
+		err     error
+	)
+
+	// Poll for receipt with timeout
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		receipt, err = client.TransactionReceipt(ctx, tx.Hash())
+		if err == nil && receipt != nil {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	if err != nil {
+		return false
+	}
+	if receipt == nil {
+		return false
+	}
+	if receipt.Status != types.ReceiptStatusSuccessful {
+		return false
+	}
+	return true
+}

--- a/miner/bidder.go
+++ b/miner/bidder.go
@@ -238,9 +238,19 @@ func (b *Bidder) bid(work *environment) {
 	// construct bid from work
 	{
 		var txs []hexutil.Bytes
+		var scIndex int
+		scs := work.sidecars.BlobTxSidecarList()
 		for _, tx := range work.txs {
 			var txBytes []byte
 			var err error
+			if tx.Type() == types.BlobTxType {
+				if scIndex >= len(scs) {
+					log.Error("Bidder: BlobTx transaction exceeds sidecar list length", "tx", tx)
+					return
+				}
+				tx = tx.WithBlobTxSidecar(scs[scIndex])
+				scIndex++
+			}
 			txBytes, err = tx.MarshalBinary()
 			if err != nil {
 				log.Error("Bidder: fail to marshal tx", "tx", tx, "err", err)

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -790,7 +790,7 @@ func (w *worker) commitBlobTransaction(env *environment, tx *types.Transaction, 
 		return nil, err
 	}
 	sc.TxIndex = uint64(len(env.txs))
-	env.txs = append(env.txs, tx)
+	env.txs = append(env.txs, tx.WithoutBlobTxSidecar())
 	env.receipts = append(env.receipts, receipt)
 	env.sidecars = append(env.sidecars, sc)
 	env.blobs += len(sc.Blobs)


### PR DESCRIPTION
### Description

In the   commitBlobTransaction   function, the presence of   blobSidecar   in   env.txs   will cause the   ValidateBody   function to fail. This failure, in turn, will have a negative impact on the rollback test.

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
