### PR TITLE
feat: implement private tx pool

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -227,7 +227,7 @@ var (
 		utils.RPCGlobalEVMTimeoutFlag,
 		utils.RPCGlobalTxFeeCapFlag,
 		utils.AllowUnprotectedTxs,
-		utils.EnablePrivateTxRPC,
+		utils.PrivateTxMode,
 		utils.BatchRequestLimit,
 		utils.BatchResponseMaxSize,
 	}

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -227,6 +227,7 @@ var (
 		utils.RPCGlobalEVMTimeoutFlag,
 		utils.RPCGlobalTxFeeCapFlag,
 		utils.AllowUnprotectedTxs,
+		utils.EnablePrivateTxRPC,
 		utils.BatchRequestLimit,
 		utils.BatchResponseMaxSize,
 	}

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -876,9 +876,9 @@ var (
 		Usage:    "Allow for unprotected (non EIP155 signed) transactions to be submitted via RPC",
 		Category: flags.APICategory,
 	}
-	EnablePrivateTxRPC = &cli.BoolFlag{
-		Name:     "rpc.enable-private-tx",
-		Usage:    "Enable private transaction rpc",
+	PrivateTxMode = &cli.BoolFlag{
+		Name:     "rpc.private-tx-mode",
+		Usage:    "Enable private transaction mode",
 		Category: flags.APICategory,
 	}
 	BatchRequestLimit = &cli.IntFlag{
@@ -1424,8 +1424,8 @@ func setHTTP(ctx *cli.Context, cfg *node.Config) {
 		cfg.AllowUnprotectedTxs = ctx.Bool(AllowUnprotectedTxs.Name)
 	}
 
-	if ctx.IsSet(EnablePrivateTxRPC.Name) {
-		cfg.EnablePrivateTxRPC = ctx.Bool(EnablePrivateTxRPC.Name)
+	if ctx.IsSet(PrivateTxMode.Name) {
+		cfg.PrivateTxMode = ctx.Bool(PrivateTxMode.Name)
 	}
 
 	if ctx.IsSet(BatchRequestLimit.Name) {

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -876,6 +876,11 @@ var (
 		Usage:    "Allow for unprotected (non EIP155 signed) transactions to be submitted via RPC",
 		Category: flags.APICategory,
 	}
+	EnablePrivateTxRPC = &cli.BoolFlag{
+		Name:     "rpc.enable-private-tx",
+		Usage:    "Enable private transaction rpc",
+		Category: flags.APICategory,
+	}
 	BatchRequestLimit = &cli.IntFlag{
 		Name:     "rpc.batch-request-limit",
 		Usage:    "Maximum number of requests in a batch",
@@ -1414,8 +1419,13 @@ func setHTTP(ctx *cli.Context, cfg *node.Config) {
 	if ctx.IsSet(HTTPPathPrefixFlag.Name) {
 		cfg.HTTPPathPrefix = ctx.String(HTTPPathPrefixFlag.Name)
 	}
+
 	if ctx.IsSet(AllowUnprotectedTxs.Name) {
 		cfg.AllowUnprotectedTxs = ctx.Bool(AllowUnprotectedTxs.Name)
+	}
+
+	if ctx.IsSet(EnablePrivateTxRPC.Name) {
+		cfg.EnablePrivateTxRPC = ctx.Bool(EnablePrivateTxRPC.Name)
 	}
 
 	if ctx.IsSet(BatchRequestLimit.Name) {

--- a/core/txpool/blobpool/blobpool.go
+++ b/core/txpool/blobpool/blobpool.go
@@ -327,6 +327,8 @@ type BlobPool struct {
 	txValidationFn txpool.ValidationFunction
 
 	lock sync.RWMutex // Mutex protecting the pool during reorg handling
+
+	privateTxs *types.TimestampedTxHashSet
 }
 
 // New creates a new blob transaction pool to gather, sort and filter inbound
@@ -344,6 +346,7 @@ func New(config Config, chain BlockChain) *BlobPool {
 		index:          make(map[common.Address][]*blobTxMeta),
 		spent:          make(map[common.Address]*uint256.Int),
 		txValidationFn: txpool.ValidateTransaction,
+		privateTxs:     types.NewExpiringTxHashSet(config.PrivateTxLifetime, metrics.NewRegisteredGauge("blobpool/private", nil)),
 	}
 }
 
@@ -548,6 +551,7 @@ func (p *BlobPool) recheck(addr common.Address, inclusions map[common.Hash]uint6
 
 			// Included transactions blobs need to be moved to the limbo
 			if filled && inclusions != nil {
+				p.privateTxs.Remove(txs[i].hash)
 				p.offload(addr, txs[i].nonce, txs[i].id, inclusions)
 			}
 		}
@@ -589,6 +593,7 @@ func (p *BlobPool) recheck(addr common.Address, inclusions map[common.Hash]uint6
 
 			// Included transactions blobs need to be moved to the limbo
 			if inclusions != nil {
+				p.privateTxs.Remove(txs[0].hash)
 				p.offload(addr, txs[0].nonce, txs[0].id, inclusions)
 			}
 			txs = txs[1:]
@@ -846,6 +851,8 @@ func (p *BlobPool) Reset(oldHead, newHead *types.Header) {
 	basefeeGauge.Update(int64(basefee.Uint64()))
 	blobfeeGauge.Update(int64(blobfee.Uint64()))
 	p.updateStorageMetrics()
+
+	p.privateTxs.Prune()
 }
 
 // reorg assembles all the transactors and missing transactions between an old
@@ -958,7 +965,7 @@ func (p *BlobPool) reorg(oldHead, newHead *types.Header) (map[common.Address][]*
 		// Generate the set that was lost to reinject into the pool
 		lost := make([]*types.Transaction, 0, len(discarded[addr]))
 		for _, tx := range types.TxDifference(discarded[addr], included[addr]) {
-			if p.Filter(tx) {
+			if p.Filter(tx) && !p.IsPrivateTxHash(tx.Hash()) {
 				lost = append(lost, tx)
 			}
 		}
@@ -1284,13 +1291,13 @@ func (p *BlobPool) GetBlobs(vhashes []common.Hash) ([]*kzg4844.Blob, []*kzg4844.
 
 // Add inserts a set of blob transactions into the pool if they pass validation (both
 // consensus validity and pool restrictions).
-func (p *BlobPool) Add(txs []*types.Transaction, sync bool) []error {
+func (p *BlobPool) Add(txs []*types.Transaction, sync bool, private bool) []error {
 	var (
 		adds = make([]*types.Transaction, 0, len(txs))
 		errs = make([]error, len(txs))
 	)
 	for i, tx := range txs {
-		errs[i] = p.add(tx)
+		errs[i] = p.add(tx, private)
 		if errs[i] == nil {
 			adds = append(adds, tx.WithoutBlobTxSidecar())
 		}
@@ -1304,7 +1311,7 @@ func (p *BlobPool) Add(txs []*types.Transaction, sync bool) []error {
 
 // add inserts a new blob transaction into the pool if it passes validation (both
 // consensus validity and pool restrictions).
-func (p *BlobPool) add(tx *types.Transaction) (err error) {
+func (p *BlobPool) add(tx *types.Transaction, private bool) (err error) {
 	// The blob pool blocks on adding a transaction. This is because blob txs are
 	// only even pulled from the network, so this method will act as the overload
 	// protection for fetches.
@@ -1370,6 +1377,11 @@ func (p *BlobPool) add(tx *types.Transaction) (err error) {
 		return err
 	}
 	meta := newBlobTxMeta(id, p.store.Size(id), tx)
+
+	// Track private transactions, so they don't get leaked to the public mempool
+	if private {
+		p.privateTxs.Add(tx.Hash())
+	}
 
 	var (
 		next   = p.state.GetNonce(from)
@@ -1787,4 +1799,8 @@ func (p *BlobPool) Clear() {
 		blobfee = uint256.NewInt(params.BlobTxMinBlobGasprice)
 	)
 	p.evict = newPriceHeap(basefee, blobfee, p.index)
+}
+
+func (p *BlobPool) IsPrivateTxHash(hash common.Hash) bool {
+	return p.privateTxs.Contains(hash)
 }

--- a/core/txpool/blobpool/blobpool_test.go
+++ b/core/txpool/blobpool/blobpool_test.go
@@ -1109,7 +1109,7 @@ func TestChangingSlotterSize(t *testing.T) {
 
 		// Try to add the big blob tx. In the initial iteration it should overflow
 		// the pool. On the subsequent iteration it should be accepted.
-		errs := pool.Add([]*types.Transaction{tx3}, true)
+		errs := pool.Add([]*types.Transaction{tx3}, true, false)
 		if _, ok := pool.index[addr3]; ok && maxBlobs == 6 {
 			t.Errorf("expected insert of oversized blob tx to fail: blobs=24, maxBlobs=%d, err=%v", maxBlobs, errs[0])
 		} else if !ok && maxBlobs == 10 {
@@ -1555,7 +1555,7 @@ func TestAdd(t *testing.T) {
 		// Add each transaction one by one, verifying the pool internals in between
 		for j, add := range tt.adds {
 			signed, _ := types.SignNewTx(keys[add.from], types.LatestSigner(params.MainnetChainConfig), add.tx)
-			if err := pool.add(signed); !errors.Is(err, add.err) {
+			if err := pool.add(signed, false); !errors.Is(err, add.err) {
 				t.Errorf("test %d, tx %d: adding transaction error mismatch: have %v, want %v", i, j, err, add.err)
 			}
 			verifyPoolInternals(t, pool)
@@ -1661,7 +1661,7 @@ func benchmarkPoolPending(b *testing.B, datacap uint64) {
 			b.Fatal(err)
 		}
 		statedb.AddBalance(addr, uint256.NewInt(1_000_000_000), tracing.BalanceChangeUnspecified)
-		pool.add(tx)
+		pool.add(tx, false)
 	}
 	statedb.Commit(0, true, false)
 	defer pool.Close()

--- a/core/txpool/blobpool/config.go
+++ b/core/txpool/blobpool/config.go
@@ -17,21 +17,25 @@
 package blobpool
 
 import (
+	"time"
+
 	"github.com/ethereum/go-ethereum/log"
 )
 
 // Config are the configuration parameters of the blob transaction pool.
 type Config struct {
-	Datadir   string // Data directory containing the currently executable blobs
-	Datacap   uint64 // Soft-cap of database storage (hard cap is larger due to overhead)
-	PriceBump uint64 // Minimum price bump percentage to replace an already existing nonce
+	Datadir           string        // Data directory containing the currently executable blobs
+	Datacap           uint64        // Soft-cap of database storage (hard cap is larger due to overhead)
+	PriceBump         uint64        // Minimum price bump percentage to replace an already existing nonce
+	PrivateTxLifetime time.Duration // Maximum amount of time to keep private transactions private
 }
 
 // DefaultConfig contains the default configurations for the transaction pool.
 var DefaultConfig = Config{
-	Datadir:   "blobpool",
-	Datacap:   10 * 1024 * 1024 * 1024 / 4, // TODO(karalabe): /4 handicap for rollout, gradually bump back up to 10GB
-	PriceBump: 100,                         // either have patience or be aggressive, no mushy ground
+	Datadir:           "blobpool",
+	Datacap:           10 * 1024 * 1024 * 1024 / 4, // TODO(karalabe): /4 handicap for rollout, gradually bump back up to 10GB
+	PriceBump:         100,                         // either have patience or be aggressive, no mushy ground
+	PrivateTxLifetime: 3 * 24 * time.Hour,
 }
 
 // sanitize checks the provided user configurations and changes anything that's
@@ -45,6 +49,10 @@ func (config *Config) sanitize() Config {
 	if conf.PriceBump < 1 {
 		log.Warn("Sanitizing invalid blobpool price bump", "provided", conf.PriceBump, "updated", DefaultConfig.PriceBump)
 		conf.PriceBump = DefaultConfig.PriceBump
+	}
+	if conf.PrivateTxLifetime < 1 {
+		log.Warn("Sanitizing invalid txpool private tx lifetime", "provided", conf.PrivateTxLifetime, "updated", DefaultConfig.PrivateTxLifetime)
+		conf.PrivateTxLifetime = DefaultConfig.PrivateTxLifetime
 	}
 	return conf
 }

--- a/core/txpool/bundlepool/bundlepool.go
+++ b/core/txpool/bundlepool/bundlepool.go
@@ -292,7 +292,7 @@ func (p *BundlePool) Get(hash common.Hash) *types.Transaction {
 // Add enqueues a batch of transactions into the pool if they are valid. Due
 // to the large transaction churn, add may postpone fully integrating the tx
 // to a later point to batch multiple ones together.
-func (p *BundlePool) Add(txs []*types.Transaction, sync bool) []error {
+func (p *BundlePool) Add(txs []*types.Transaction, sync bool, private bool) []error {
 	return nil
 }
 
@@ -300,6 +300,11 @@ func (p *BundlePool) Add(txs []*types.Transaction, sync bool) []error {
 // account and sorted by nonce.
 func (p *BundlePool) Pending(filter txpool.PendingFilter) map[common.Address][]*txpool.LazyTransaction {
 	return nil
+}
+
+// IsPrivateTxHash returns true if the transaction is a private transaction.
+func (p *BundlePool) IsPrivateTxHash(hash common.Hash) bool {
+	return false
 }
 
 // SubscribeTransactions subscribes to new transaction events.

--- a/core/txpool/legacypool/legacypool_test.go
+++ b/core/txpool/legacypool/legacypool_test.go
@@ -1467,14 +1467,14 @@ func TestMinGasPriceEnforced(t *testing.T) {
 	tx := pricedTransaction(0, 100000, big.NewInt(2), key)
 	pool.SetGasTip(big.NewInt(tx.GasPrice().Int64() + 1))
 
-	if err := pool.Add([]*types.Transaction{tx}, true)[0]; !errors.Is(err, txpool.ErrUnderpriced) {
+	if err := pool.Add([]*types.Transaction{tx}, true, false)[0]; !errors.Is(err, txpool.ErrUnderpriced) {
 		t.Fatalf("Min tip not enforced")
 	}
 
 	tx = dynamicFeeTx(0, 100000, big.NewInt(3), big.NewInt(2), key)
 	pool.SetGasTip(big.NewInt(tx.GasTipCap().Int64() + 1))
 
-	if err := pool.Add([]*types.Transaction{tx}, true)[0]; !errors.Is(err, txpool.ErrUnderpriced) {
+	if err := pool.Add([]*types.Transaction{tx}, true, false)[0]; !errors.Is(err, txpool.ErrUnderpriced) {
 		t.Fatalf("Min tip not enforced")
 	}
 }
@@ -2311,7 +2311,7 @@ func TestTransactionPendingReannouce(t *testing.T) {
 	for i := uint64(0); i < testTxPoolConfig.AccountQueue; i++ {
 		txs = append(txs, transaction(i, 100000, key))
 	}
-	pool.Add(txs, true)
+	pool.Add(txs, true, false)
 
 	select {
 	case ev := <-events:

--- a/core/txpool/locals/tx_tracker.go
+++ b/core/txpool/locals/tx_tracker.go
@@ -74,18 +74,23 @@ func New(journalPath string, journalTime time.Duration, chainConfig *params.Chai
 
 // Track adds a transaction to the tracked set.
 // Note: blob-type transactions are ignored.
+// Note: private transactions are ignored.
 func (tracker *TxTracker) Track(tx *types.Transaction) {
 	tracker.TrackAll([]*types.Transaction{tx})
 }
 
 // TrackAll adds a list of transactions to the tracked set.
 // Note: blob-type transactions are ignored.
+// Note: private transactions are ignored.
 func (tracker *TxTracker) TrackAll(txs []*types.Transaction) {
 	tracker.mu.Lock()
 	defer tracker.mu.Unlock()
 
 	for _, tx := range txs {
 		if tx.Type() == types.BlobTxType {
+			continue
+		}
+		if tracker.pool.IsPrivateTxHash(tx.Hash()) {
 			continue
 		}
 		// If we're already tracking it, it's a no-op
@@ -195,7 +200,7 @@ func (tracker *TxTracker) loop() {
 			checkJournal := tracker.journal != nil && time.Since(lastJournal) > tracker.rejournal
 			resubmits, rejournal := tracker.recheck(checkJournal)
 			if len(resubmits) > 0 {
-				tracker.pool.Add(resubmits, false)
+				tracker.pool.Add(resubmits, false, false)
 			}
 			if checkJournal {
 				// Lock to prevent journal.rotate <-> journal.insert (via TrackAll) conflicts

--- a/core/txpool/subpool.go
+++ b/core/txpool/subpool.go
@@ -133,7 +133,7 @@ type SubPool interface {
 	// Add enqueues a batch of transactions into the pool if they are valid. Due
 	// to the large transaction churn, add may postpone fully integrating the tx
 	// to a later point to batch multiple ones together.
-	Add(txs []*types.Transaction, sync bool) []error
+	Add(txs []*types.Transaction, sync bool, private bool) []error
 
 	// Pending retrieves all currently processable transactions, grouped by origin
 	// account and sorted by nonce.
@@ -141,6 +141,10 @@ type SubPool interface {
 	// The transactions can also be pre-filtered by the dynamic fee components to
 	// reduce allocations and load on downstream subsystems.
 	Pending(filter PendingFilter) map[common.Address][]*LazyTransaction
+
+	// IsPrivateTxHash returns true if the transaction is a private transaction.
+	// This is used to filter out private transactions from the pool.
+	IsPrivateTxHash(hash common.Hash) bool
 
 	// SubscribeTransactions subscribes to new transaction events. The subscriber
 	// can decide whether to receive notifications only for newly seen transactions

--- a/core/txpool/txpool.go
+++ b/core/txpool/txpool.go
@@ -334,7 +334,7 @@ func (p *TxPool) GetBlobs(vhashes []common.Hash) ([]*kzg4844.Blob, []*kzg4844.Pr
 // Add enqueues a batch of transactions into the pool if they are valid. Due
 // to the large transaction churn, add may postpone fully integrating the tx
 // to a later point to batch multiple ones together.
-func (p *TxPool) Add(txs []*types.Transaction, sync bool) []error {
+func (p *TxPool) Add(txs []*types.Transaction, sync bool, private bool) []error {
 	// Split the input transactions between the subpools. It shouldn't really
 	// happen that we receive merged batches, but better graceful than strange
 	// errors.
@@ -361,7 +361,7 @@ func (p *TxPool) Add(txs []*types.Transaction, sync bool) []error {
 	// back the errors into the original sort order.
 	errsets := make([][]error, len(p.subpools))
 	for i := 0; i < len(p.subpools); i++ {
-		errsets[i] = p.subpools[i].Add(txsets[i], sync)
+		errsets[i] = p.subpools[i].Add(txsets[i], sync, private)
 	}
 	errs := make([]error, len(txs))
 	for i, split := range splits {
@@ -565,4 +565,13 @@ func (p *TxPool) Clear() {
 	for _, subpool := range p.subpools {
 		subpool.Clear()
 	}
+}
+
+func (p *TxPool) IsPrivateTxHash(hash common.Hash) bool {
+	for _, subpool := range p.subpools {
+		if subpool.IsPrivateTxHash(hash) {
+			return true
+		}
+	}
+	return false
 }

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -22,11 +22,13 @@ import (
 	"fmt"
 	"io"
 	"math/big"
+	"sync"
 	"sync/atomic"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/metrics"
 	"github.com/ethereum/go-ethereum/rlp"
 )
 
@@ -664,4 +666,63 @@ func copyAddressPtr(a *common.Address) *common.Address {
 	}
 	cpy := *a
 	return &cpy
+}
+
+type TimestampedTxHashSet struct {
+	lock       sync.RWMutex
+	timestamps map[common.Hash]time.Time
+	ttl        time.Duration
+	metrics    *metrics.Gauge
+}
+
+func NewExpiringTxHashSet(ttl time.Duration, metrics *metrics.Gauge) *TimestampedTxHashSet {
+	s := &TimestampedTxHashSet{
+		timestamps: make(map[common.Hash]time.Time),
+		ttl:        ttl,
+		metrics:    metrics,
+	}
+
+	return s
+}
+
+func (s *TimestampedTxHashSet) Add(hash common.Hash) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	_, ok := s.timestamps[hash]
+	if !ok {
+		s.timestamps[hash] = time.Now().Add(s.ttl)
+		s.metrics.Inc(1)
+	}
+}
+
+func (s *TimestampedTxHashSet) Contains(hash common.Hash) bool {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+	_, ok := s.timestamps[hash]
+	return ok
+}
+
+func (s *TimestampedTxHashSet) Remove(hash common.Hash) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	_, ok := s.timestamps[hash]
+	if ok {
+		delete(s.timestamps, hash)
+		s.metrics.Dec(1)
+	}
+}
+
+func (s *TimestampedTxHashSet) Prune() {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	now := time.Now()
+	for hash, ts := range s.timestamps {
+		if ts.Before(now) {
+			delete(s.timestamps, hash)
+		}
+	}
+	s.metrics.Update(int64(len(s.timestamps)))
 }

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -51,6 +51,7 @@ import (
 type EthAPIBackend struct {
 	extRPCEnabled       bool
 	allowUnprotectedTxs bool
+	enablePrivateTxRPC  bool
 	eth                 *Ethereum
 	gpo                 *gasprice.Oracle
 }
@@ -473,6 +474,10 @@ func (b *EthAPIBackend) ExtRPCEnabled() bool {
 
 func (b *EthAPIBackend) UnprotectedAllowed() bool {
 	return b.allowUnprotectedTxs
+}
+
+func (b *EthAPIBackend) EnablePrivateTxRPC() bool {
+	return b.enablePrivateTxRPC
 }
 
 func (b *EthAPIBackend) RPCGasCap() uint64 {

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -290,11 +290,17 @@ func (b *EthAPIBackend) SubscribeLogsEvent(ch chan<- []*types.Log) event.Subscri
 	return b.eth.BlockChain().SubscribeLogsEvent(ch)
 }
 
-func (b *EthAPIBackend) SendTx(ctx context.Context, signedTx *types.Transaction) error {
+func (b *EthAPIBackend) SendTx(ctx context.Context, signedTx *types.Transaction, private bool) error {
 	if locals := b.eth.localTxTracker; locals != nil {
-		locals.Track(signedTx)
+		if !private {
+			locals.Track(signedTx)
+		}
 	}
-	return b.eth.txPool.Add([]*types.Transaction{signedTx}, false)[0]
+	if private {
+		return b.eth.txPool.Add([]*types.Transaction{signedTx}, false, true)[0]
+	}
+
+	return b.eth.txPool.Add([]*types.Transaction{signedTx}, false, false)[0]
 }
 
 func (b *EthAPIBackend) SendBundle(ctx context.Context, bundle *types.Bundle) error {

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -51,7 +51,7 @@ import (
 type EthAPIBackend struct {
 	extRPCEnabled       bool
 	allowUnprotectedTxs bool
-	enablePrivateTxRPC  bool
+	privateTxMode       bool
 	eth                 *Ethereum
 	gpo                 *gasprice.Oracle
 }
@@ -476,8 +476,8 @@ func (b *EthAPIBackend) UnprotectedAllowed() bool {
 	return b.allowUnprotectedTxs
 }
 
-func (b *EthAPIBackend) EnablePrivateTxRPC() bool {
-	return b.enablePrivateTxRPC
+func (b *EthAPIBackend) PrivateTxMode() bool {
+	return b.privateTxMode
 }
 
 func (b *EthAPIBackend) RPCGasCap() uint64 {

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -256,9 +256,12 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 		stopReportCh:      make(chan struct{}, 1),
 	}
 
-	eth.APIBackend = &EthAPIBackend{stack.Config().ExtRPCEnabled(), stack.Config().AllowUnprotectedTxs, eth, nil}
+	eth.APIBackend = &EthAPIBackend{stack.Config().ExtRPCEnabled(), stack.Config().AllowUnprotectedTxs, stack.Config().EnablePrivateTxRPC, eth, nil}
 	if eth.APIBackend.allowUnprotectedTxs {
 		log.Info("Unprotected transactions allowed")
+	}
+	if eth.APIBackend.enablePrivateTxRPC {
+		log.Info("Private transactions allowed")
 	}
 	ethAPI := ethapi.NewBlockChainAPI(eth.APIBackend)
 	eth.engine, err = ethconfig.CreateConsensusEngine(chainConfig, chainDb, ethAPI, genesisHash)

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -256,12 +256,12 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 		stopReportCh:      make(chan struct{}, 1),
 	}
 
-	eth.APIBackend = &EthAPIBackend{stack.Config().ExtRPCEnabled(), stack.Config().AllowUnprotectedTxs, stack.Config().EnablePrivateTxRPC, eth, nil}
+	eth.APIBackend = &EthAPIBackend{stack.Config().ExtRPCEnabled(), stack.Config().AllowUnprotectedTxs, stack.Config().PrivateTxMode, eth, nil}
 	if eth.APIBackend.allowUnprotectedTxs {
 		log.Info("Unprotected transactions allowed")
 	}
-	if eth.APIBackend.enablePrivateTxRPC {
-		log.Info("Private transactions allowed")
+	if eth.APIBackend.privateTxMode {
+		log.Info("Private transaction mode enabled")
 	}
 	ethAPI := ethapi.NewBlockChainAPI(eth.APIBackend)
 	eth.engine, err = ethconfig.CreateConsensusEngine(chainConfig, chainDb, ethAPI, genesisHash)

--- a/eth/catalyst/simulated_beacon_test.go
+++ b/eth/catalyst/simulated_beacon_test.go
@@ -114,7 +114,7 @@ func testSimulatedBeaconSendWithdrawals(t *testing.T) {
 		}
 		txs[tx.Hash()] = tx
 
-		if err := ethService.APIBackend.SendTx(context.Background(), tx); err != nil {
+		if err := ethService.APIBackend.SendTx(context.Background(), tx, false); err != nil {
 			t.Fatal("SendTx failed", err)
 		}
 	}
@@ -182,7 +182,7 @@ func TestOnDemandSpam(t *testing.T) {
 			if err != nil {
 				panic(fmt.Sprintf("error signing transaction: %v", err))
 			}
-			if err := eth.TxPool().Add([]*types.Transaction{tx}, false)[0]; err != nil {
+			if err := eth.TxPool().Add([]*types.Transaction{tx}, false, false)[0]; err != nil {
 				panic(fmt.Sprintf("error adding txs to pool: %v", err))
 			}
 		}

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -83,11 +83,14 @@ type txPool interface {
 	Get(hash common.Hash) *types.Transaction
 
 	// Add should add the given transactions to the pool.
-	Add(txs []*types.Transaction, sync bool) []error
+	Add(txs []*types.Transaction, sync bool, private bool) []error
 
 	// Pending should return pending transactions.
 	// The slice should be modifiable by the caller.
 	Pending(filter txpool.PendingFilter) map[common.Address][]*txpool.LazyTransaction
+
+	// IsPrivateTxHash returns true if the transaction is a private transaction.
+	IsPrivateTxHash(hash common.Hash) bool
 
 	// SubscribeTransactions subscribes to new transaction events. The subscriber
 	// can decide whether to receive notifications only for newly seen transactions
@@ -305,7 +308,7 @@ func newHandler(config *handlerConfig) (*handler, error) {
 		return p.RequestTxs(hashes)
 	}
 	addTxs := func(peer string, txs []*types.Transaction) []error {
-		errors := h.txpool.Add(txs, false)
+		errors := h.txpool.Add(txs, false, false)
 		for _, err := range errors {
 			if err == txpool.ErrInBlackList {
 				accountBlacklistPeerCounter.Inc(1)

--- a/eth/handler_eth_test.go
+++ b/eth/handler_eth_test.go
@@ -394,8 +394,8 @@ func testSendTransactions(t *testing.T, protocol uint) {
 		tx, _ = types.SignTx(tx, types.HomesteadSigner{}, testKey)
 		insert[nonce] = tx
 	}
-	go handler.txpool.Add(insert, false) // Need goroutine to not block on feed
-	time.Sleep(250 * time.Millisecond)   // Wait until tx events get out of the system (can't use events, tx broadcaster races with peer join)
+	go handler.txpool.Add(insert, false, false) // Need goroutine to not block on feed
+	time.Sleep(250 * time.Millisecond)          // Wait until tx events get out of the system (can't use events, tx broadcaster races with peer join)
 
 	// Create a source handler to send messages through and a sink peer to receive them
 	p2pSrc, p2pSink := p2p.MsgPipe()
@@ -515,7 +515,7 @@ func testTransactionPropagation(t *testing.T, protocol uint) {
 		tx, _ = types.SignTx(tx, types.HomesteadSigner{}, testKey)
 		txs[nonce] = tx
 	}
-	source.txpool.Add(txs, false)
+	source.txpool.Add(txs, false, false)
 
 	// Iterate through all the sinks and ensure they all got the transactions
 	for i := range sinks {

--- a/eth/handler_test.go
+++ b/eth/handler_test.go
@@ -90,7 +90,7 @@ func (p *testTxPool) Get(hash common.Hash) *types.Transaction {
 
 // Add appends a batch of transactions to the pool, and notifies any
 // listeners if the addition channel is non nil
-func (p *testTxPool) Add(txs []*types.Transaction, sync bool) []error {
+func (p *testTxPool) Add(txs []*types.Transaction, sync bool, private bool) []error {
 	p.lock.Lock()
 	defer p.lock.Unlock()
 
@@ -141,6 +141,11 @@ func (p *testTxPool) Pending(filter txpool.PendingFilter) map[common.Address][]*
 		}
 	}
 	return pending
+}
+
+// IsPrivateTxHash returns true if the transaction is a private transaction.
+func (p *testTxPool) IsPrivateTxHash(hash common.Hash) bool {
+	return false
 }
 
 // SubscribeTransactions should return an event subscription of NewTxsEvent and

--- a/eth/sync.go
+++ b/eth/sync.go
@@ -39,7 +39,9 @@ func (h *handler) syncTransactions(p *eth.Peer) {
 	var hashes []common.Hash
 	for _, batch := range h.txpool.Pending(txpool.PendingFilter{OnlyPlainTxs: true}) {
 		for _, tx := range batch {
-			hashes = append(hashes, tx.Hash)
+			if !h.txpool.IsPrivateTxHash(tx.Hash) {
+				hashes = append(hashes, tx.Hash)
+			}
 		}
 	}
 	if len(hashes) == 0 {

--- a/graphql/graphql.go
+++ b/graphql/graphql.go
@@ -1393,7 +1393,16 @@ func (r *Resolver) SendRawTransaction(ctx context.Context, args struct{ Data hex
 	if err := tx.UnmarshalBinary(args.Data); err != nil {
 		return common.Hash{}, err
 	}
-	hash, err := ethapi.SubmitTransaction(ctx, r.backend, tx)
+	hash, err := ethapi.SubmitTransaction(ctx, r.backend, tx, true)
+	return hash, err
+}
+
+func (r *Resolver) SendPrivateRawTransaction(ctx context.Context, args struct{ Data hexutil.Bytes }) (common.Hash, error) {
+	tx := new(types.Transaction)
+	if err := tx.UnmarshalBinary(args.Data); err != nil {
+		return common.Hash{}, err
+	}
+	hash, err := ethapi.SubmitTransaction(ctx, r.backend, tx, true)
 	return hash, err
 }
 

--- a/graphql/graphql.go
+++ b/graphql/graphql.go
@@ -1393,7 +1393,7 @@ func (r *Resolver) SendRawTransaction(ctx context.Context, args struct{ Data hex
 	if err := tx.UnmarshalBinary(args.Data); err != nil {
 		return common.Hash{}, err
 	}
-	hash, err := ethapi.SubmitTransaction(ctx, r.backend, tx, true)
+	hash, err := ethapi.SubmitTransaction(ctx, r.backend, tx, r.backend.EnablePrivateTxRPC())
 	return hash, err
 }
 

--- a/graphql/graphql.go
+++ b/graphql/graphql.go
@@ -1393,7 +1393,7 @@ func (r *Resolver) SendRawTransaction(ctx context.Context, args struct{ Data hex
 	if err := tx.UnmarshalBinary(args.Data); err != nil {
 		return common.Hash{}, err
 	}
-	hash, err := ethapi.SubmitTransaction(ctx, r.backend, tx, r.backend.EnablePrivateTxRPC())
+	hash, err := ethapi.SubmitTransaction(ctx, r.backend, tx, r.backend.PrivateTxMode())
 	return hash, err
 }
 

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -2144,7 +2144,7 @@ func (api *TransactionAPI) SendTransaction(ctx context.Context, args Transaction
 	if err != nil {
 		return common.Hash{}, err
 	}
-	return SubmitTransaction(ctx, api.b, signed, api.b.EnablePrivateTxRPC())
+	return SubmitTransaction(ctx, api.b, signed, api.b.PrivateTxMode())
 }
 
 // FillTransaction fills the defaults (nonce, gas, gasPrice or 1559 fields)
@@ -2173,7 +2173,7 @@ func (api *TransactionAPI) SendRawTransaction(ctx context.Context, input hexutil
 	if err := tx.UnmarshalBinary(input); err != nil {
 		return common.Hash{}, err
 	}
-	return SubmitTransaction(ctx, api.b, tx, api.b.EnablePrivateTxRPC())
+	return SubmitTransaction(ctx, api.b, tx, api.b.PrivateTxMode())
 }
 
 // SendRawTransactionConditional will add the signed transaction to the transaction pool.
@@ -2191,7 +2191,7 @@ func (api *TransactionAPI) SendRawTransactionConditional(ctx context.Context, in
 	if err := TxOptsCheck(opts, header.Number.Uint64(), header.Time, state); err != nil {
 		return common.Hash{}, err
 	}
-	return SubmitTransaction(ctx, api.b, tx, api.b.EnablePrivateTxRPC())
+	return SubmitTransaction(ctx, api.b, tx, api.b.PrivateTxMode())
 }
 
 // SendPrivateRawTransaction will add the signed transaction to the transaction pool,

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -2144,7 +2144,7 @@ func (api *TransactionAPI) SendTransaction(ctx context.Context, args Transaction
 	if err != nil {
 		return common.Hash{}, err
 	}
-	return SubmitTransaction(ctx, api.b, signed, true)
+	return SubmitTransaction(ctx, api.b, signed, api.b.EnablePrivateTxRPC())
 }
 
 // FillTransaction fills the defaults (nonce, gas, gasPrice or 1559 fields)
@@ -2173,7 +2173,7 @@ func (api *TransactionAPI) SendRawTransaction(ctx context.Context, input hexutil
 	if err := tx.UnmarshalBinary(input); err != nil {
 		return common.Hash{}, err
 	}
-	return SubmitTransaction(ctx, api.b, tx, true)
+	return SubmitTransaction(ctx, api.b, tx, api.b.EnablePrivateTxRPC())
 }
 
 // SendRawTransactionConditional will add the signed transaction to the transaction pool.
@@ -2191,7 +2191,7 @@ func (api *TransactionAPI) SendRawTransactionConditional(ctx context.Context, in
 	if err := TxOptsCheck(opts, header.Number.Uint64(), header.Time, state); err != nil {
 		return common.Hash{}, err
 	}
-	return SubmitTransaction(ctx, api.b, tx, true)
+	return SubmitTransaction(ctx, api.b, tx, api.b.EnablePrivateTxRPC())
 }
 
 // SendPrivateRawTransaction will add the signed transaction to the transaction pool,

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -2081,7 +2081,7 @@ func (api *TransactionAPI) sign(addr common.Address, tx *types.Transaction) (*ty
 }
 
 // SubmitTransaction is a helper function that submits tx to txPool and logs a message.
-func SubmitTransaction(ctx context.Context, b Backend, tx *types.Transaction) (common.Hash, error) {
+func SubmitTransaction(ctx context.Context, b Backend, tx *types.Transaction, private bool) (common.Hash, error) {
 	// If the transaction fee cap is already specified, ensure the
 	// fee of the given transaction is _reasonable_.
 	if err := checkTxFee(tx.GasPrice(), tx.Gas(), b.RPCTxFeeCap()); err != nil {
@@ -2091,7 +2091,7 @@ func SubmitTransaction(ctx context.Context, b Backend, tx *types.Transaction) (c
 		// Ensure only eip155 signed transactions are submitted if EIP155Required is set.
 		return common.Hash{}, errors.New("only replay-protected (EIP-155) transactions allowed over RPC")
 	}
-	if err := b.SendTx(ctx, tx); err != nil {
+	if err := b.SendTx(ctx, tx, private); err != nil {
 		return common.Hash{}, err
 	}
 	// Print a log with full tx details for manual investigations and interventions
@@ -2144,7 +2144,7 @@ func (api *TransactionAPI) SendTransaction(ctx context.Context, args Transaction
 	if err != nil {
 		return common.Hash{}, err
 	}
-	return SubmitTransaction(ctx, api.b, signed)
+	return SubmitTransaction(ctx, api.b, signed, true)
 }
 
 // FillTransaction fills the defaults (nonce, gas, gasPrice or 1559 fields)
@@ -2173,7 +2173,7 @@ func (api *TransactionAPI) SendRawTransaction(ctx context.Context, input hexutil
 	if err := tx.UnmarshalBinary(input); err != nil {
 		return common.Hash{}, err
 	}
-	return SubmitTransaction(ctx, api.b, tx)
+	return SubmitTransaction(ctx, api.b, tx, true)
 }
 
 // SendRawTransactionConditional will add the signed transaction to the transaction pool.
@@ -2191,7 +2191,20 @@ func (api *TransactionAPI) SendRawTransactionConditional(ctx context.Context, in
 	if err := TxOptsCheck(opts, header.Number.Uint64(), header.Time, state); err != nil {
 		return common.Hash{}, err
 	}
-	return SubmitTransaction(ctx, api.b, tx)
+	return SubmitTransaction(ctx, api.b, tx, true)
+}
+
+// SendPrivateRawTransaction will add the signed transaction to the transaction pool,
+// without broadcasting the transaction to its peers, and mark the transaction to avoid
+// future syncs.
+//
+// See SendRawTransaction.
+func (s *TransactionAPI) SendPrivateRawTransaction(ctx context.Context, input hexutil.Bytes) (common.Hash, error) {
+	tx := new(types.Transaction)
+	if err := tx.UnmarshalBinary(input); err != nil {
+		return common.Hash{}, err
+	}
+	return SubmitTransaction(ctx, s.b, tx, true)
 }
 
 // Sign calculates an ECDSA signature for:
@@ -2336,7 +2349,7 @@ func (api *TransactionAPI) Resend(ctx context.Context, sendArgs TransactionArgs,
 			if err != nil {
 				return common.Hash{}, err
 			}
-			if err = api.b.SendTx(ctx, signedTx); err != nil {
+			if err = api.b.SendTx(ctx, signedTx, false); err != nil {
 				return common.Hash{}, err
 			}
 			return signedTx.Hash(), nil

--- a/internal/ethapi/api_test.go
+++ b/internal/ethapi/api_test.go
@@ -494,6 +494,7 @@ func (b testBackend) RPCGasCap() uint64                        { return 10000000
 func (b testBackend) RPCEVMTimeout() time.Duration             { return time.Second }
 func (b testBackend) RPCTxFeeCap() float64                     { return 0 }
 func (b testBackend) UnprotectedAllowed() bool                 { return false }
+func (b testBackend) EnablePrivateTxRPC() bool                 { return false }
 func (b testBackend) SetHead(number uint64)                    {}
 func (b testBackend) HeaderByNumber(ctx context.Context, number rpc.BlockNumber) (*types.Header, error) {
 	if number == rpc.LatestBlockNumber {

--- a/internal/ethapi/api_test.go
+++ b/internal/ethapi/api_test.go
@@ -610,7 +610,7 @@ func (b testBackend) SubscribeFinalizedHeaderEvent(ch chan<- core.FinalizedHeade
 func (b testBackend) SubscribeNewVoteEvent(ch chan<- core.NewVoteEvent) event.Subscription {
 	panic("implement me")
 }
-func (b testBackend) SendTx(ctx context.Context, signedTx *types.Transaction) error {
+func (b testBackend) SendTx(ctx context.Context, signedTx *types.Transaction, private bool) error {
 	panic("implement me")
 }
 func (b testBackend) SendBundle(ctx context.Context, bundle *types.Bundle) error {

--- a/internal/ethapi/api_test.go
+++ b/internal/ethapi/api_test.go
@@ -494,7 +494,7 @@ func (b testBackend) RPCGasCap() uint64                        { return 10000000
 func (b testBackend) RPCEVMTimeout() time.Duration             { return time.Second }
 func (b testBackend) RPCTxFeeCap() float64                     { return 0 }
 func (b testBackend) UnprotectedAllowed() bool                 { return false }
-func (b testBackend) EnablePrivateTxRPC() bool                 { return false }
+func (b testBackend) PrivateTxMode() bool                      { return false }
 func (b testBackend) SetHead(number uint64)                    {}
 func (b testBackend) HeaderByNumber(ctx context.Context, number rpc.BlockNumber) (*types.Header, error) {
 	if number == rpc.LatestBlockNumber {

--- a/internal/ethapi/backend.go
+++ b/internal/ethapi/backend.go
@@ -77,7 +77,7 @@ type Backend interface {
 	GetBlobSidecars(ctx context.Context, hash common.Hash) (types.BlobSidecars, error)
 
 	// Transaction pool API
-	SendTx(ctx context.Context, signedTx *types.Transaction) error
+	SendTx(ctx context.Context, signedTx *types.Transaction, private bool) error
 	SendBundle(ctx context.Context, bundle *types.Bundle) error
 	SimulateGaslessBundle(bundle *types.Bundle) (*types.SimulateGaslessBundleResp, error)
 	BundlePrice() *big.Int

--- a/internal/ethapi/backend.go
+++ b/internal/ethapi/backend.go
@@ -55,6 +55,7 @@ type Backend interface {
 	RPCEVMTimeout() time.Duration // global timeout for eth_call over rpc: DoS protection
 	RPCTxFeeCap() float64         // global tx fee cap for all transaction related APIs
 	UnprotectedAllowed() bool     // allows only for EIP155 transactions.
+	EnablePrivateTxRPC() bool     // enable private tx rpc
 
 	// Blockchain API
 	SetHead(number uint64)

--- a/internal/ethapi/backend.go
+++ b/internal/ethapi/backend.go
@@ -55,7 +55,7 @@ type Backend interface {
 	RPCEVMTimeout() time.Duration // global timeout for eth_call over rpc: DoS protection
 	RPCTxFeeCap() float64         // global tx fee cap for all transaction related APIs
 	UnprotectedAllowed() bool     // allows only for EIP155 transactions.
-	EnablePrivateTxRPC() bool     // enable private tx rpc
+	PrivateTxMode() bool          // enable private tx rpc
 
 	// Blockchain API
 	SetHead(number uint64)

--- a/internal/ethapi/transaction_args_test.go
+++ b/internal/ethapi/transaction_args_test.go
@@ -336,6 +336,7 @@ func (b *backendMock) RPCGasCap() uint64                 { return 0 }
 func (b *backendMock) RPCEVMTimeout() time.Duration      { return time.Second }
 func (b *backendMock) RPCTxFeeCap() float64              { return 0 }
 func (b *backendMock) UnprotectedAllowed() bool          { return false }
+func (b *backendMock) EnablePrivateTxRPC() bool          { return false }
 func (b *backendMock) SetHead(number uint64)             {}
 func (b *backendMock) HeaderByNumber(ctx context.Context, number rpc.BlockNumber) (*types.Header, error) {
 	return nil, nil

--- a/internal/ethapi/transaction_args_test.go
+++ b/internal/ethapi/transaction_args_test.go
@@ -336,7 +336,7 @@ func (b *backendMock) RPCGasCap() uint64                 { return 0 }
 func (b *backendMock) RPCEVMTimeout() time.Duration      { return time.Second }
 func (b *backendMock) RPCTxFeeCap() float64              { return 0 }
 func (b *backendMock) UnprotectedAllowed() bool          { return false }
-func (b *backendMock) EnablePrivateTxRPC() bool          { return false }
+func (b *backendMock) PrivateTxMode() bool               { return false }
 func (b *backendMock) SetHead(number uint64)             {}
 func (b *backendMock) HeaderByNumber(ctx context.Context, number rpc.BlockNumber) (*types.Header, error) {
 	return nil, nil

--- a/internal/ethapi/transaction_args_test.go
+++ b/internal/ethapi/transaction_args_test.go
@@ -389,8 +389,10 @@ func (b *backendMock) SubscribeFinalizedHeaderEvent(ch chan<- core.FinalizedHead
 func (b *backendMock) SubscribeNewVoteEvent(ch chan<- core.NewVoteEvent) event.Subscription {
 	return nil
 }
-func (b *backendMock) SendTx(ctx context.Context, signedTx *types.Transaction) error { return nil }
-func (b *backendMock) SendBundle(ctx context.Context, bundle *types.Bundle) error    { return nil }
+func (b *backendMock) SendTx(ctx context.Context, signedTx *types.Transaction, private bool) error {
+	return nil
+}
+func (b *backendMock) SendBundle(ctx context.Context, bundle *types.Bundle) error { return nil }
 func (b *backendMock) SimulateGaslessBundle(bundle *types.Bundle) (*types.SimulateGaslessBundleResp, error) {
 	//TODO implement me
 	panic("implement me")

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -500,6 +500,12 @@ web3._extend({
 			inputFormatter: [web3._extend.formatters.inputTransactionFormatter]
 		}),
 		new web3._extend.Method({
+ 			name: 'sendPrivateRawTransaction',
+ 			call: 'eth_sendPrivateRawTransaction',
+ 			params: 1,
+ 			inputFormatter: [web3._extend.formatters.inputTransactionFormatter]
+ 		}),
+		new web3._extend.Method({
 			name: 'fillTransaction',
 			call: 'eth_fillTransaction',
 			params: 1,

--- a/miner/bid_simulator.go
+++ b/miner/bid_simulator.go
@@ -126,6 +126,8 @@ func newBidSimulator(
 	engine consensus.Engine,
 	bidWorker bidWorker,
 ) *bidSimulator {
+	// Set default value
+
 	b := &bidSimulator{
 		config:        config,
 		minGasPrice:   minGasPrice,

--- a/miner/bidder.go
+++ b/miner/bidder.go
@@ -189,6 +189,7 @@ func (b *Bidder) register(cfg minerconfig.ValidatorConfig) {
 		BidSimulationLeftOver: params.BidSimulationLeftOver,
 		GasCeil:               params.GasCeil,
 	}
+	log.Info("Bidder: register", "validator", cfg.Address, "params", params)
 }
 
 func (b *Bidder) unregister(validator common.Address) {

--- a/node/config.go
+++ b/node/config.go
@@ -209,6 +209,9 @@ type Config struct {
 	// AllowUnprotectedTxs allows non EIP-155 protected transactions to be send over RPC.
 	AllowUnprotectedTxs bool `toml:",omitempty"`
 
+	// EnablePrivateTxRPC is a flag that whether to enable the private tx rpc
+	EnablePrivateTxRPC bool `toml:",omitempty"`
+
 	// EnableDoubleSignMonitor is a flag that whether to enable the double signature checker
 	EnableDoubleSignMonitor bool `toml:",omitempty"`
 

--- a/node/config.go
+++ b/node/config.go
@@ -209,8 +209,8 @@ type Config struct {
 	// AllowUnprotectedTxs allows non EIP-155 protected transactions to be send over RPC.
 	AllowUnprotectedTxs bool `toml:",omitempty"`
 
-	// EnablePrivateTxRPC is a flag that whether to enable the private tx rpc
-	EnablePrivateTxRPC bool `toml:",omitempty"`
+	// PrivateTxMode is a flag that whether to enable the private tx rpc
+	PrivateTxMode bool `toml:",omitempty"`
 
 	// EnableDoubleSignMonitor is a flag that whether to enable the double signature checker
 	EnableDoubleSignMonitor bool `toml:",omitempty"`


### PR DESCRIPTION
### Description

implement private tx pool

### Rationale
The private transaction pool addresses the need for secure and efficient transaction processing in BSC’s MEV market. It prevents attacks like sandwiching (e.g., front-running high-value swaps), improving market fairness and user trust.

### Example
```bash
curl http://localhost:8545/ \
  -X POST \
  -H "Content-Type: application/json" \
  --data '{"jsonrpc":"2.0","method":"eth_sendPrivateRawTransaction","params":["0x..."],"id":1}'
```

### Changes

Notable changes: 
* txpool
